### PR TITLE
Fix: Parse body as base64 if couldn't parse as json

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For Maven users, add dependency to your `pom.xml`:
 <dependency>
 	<groupId>com.moesif</groupId>
 	<artifactId>moesif-okhttp-interceptor</artifactId>
-	<version>1.0.5</version>
+	<version>1.0.6</version>
 </dependency> 
 ```  
 For Gradle users, add to your project's build.gradle file:  
@@ -32,7 +32,7 @@ For Gradle users, add to your project's build.gradle file:
 ```gradle  
 repositories {  
   dependencies {     
-    implementation 'com.moesif:moesif-okhttp-interceptor:1.0.5'
+    implementation 'com.moesif:moesif-okhttp-interceptor:1.0.6'
 }
 ```  
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.moesif</groupId>
   <artifactId>moesif-okhttp-interceptor</artifactId>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <packaging>jar</packaging>
   <name>moesif-okhttp-interceptor</name>
   <url>https://www.moesif.com</url>

--- a/src/main/java/com/moesif/sdk/okhttp3client/MoesifResponseHandler.java
+++ b/src/main/java/com/moesif/sdk/okhttp3client/MoesifResponseHandler.java
@@ -122,8 +122,14 @@ public class MoesifResponseHandler implements ResponseHandler {
             throws IOException {
         if ((null != bodyStream) && (bodyStream.size() <= maxAllowedBodySize)){
             if (isJsonHeader) {
-                loggedResponse.setBody(
+                try {
+                    loggedResponse.setBody(
                         JsonSerialize.jsonBAOutStreamToObj(bodyStream));
+                } catch (Exception e) {
+                    loggedResponse.setBody(
+                        EncodeUtils.BaosToB64Str(bodyStream));
+                    loggedResponse.setTransferEncoding("base64");    
+                }
             } else {
                 loggedResponse.setBody(
                         EncodeUtils.BaosToB64Str(bodyStream));


### PR DESCRIPTION
Fix: Parse body as base64 if couldn't parse as json 
Bump version to 1.0.6