### PR TITLE
Fix project transitive deps with BOM and synced updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,24 @@
     </developer>
   </developers>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp-bom</artifactId>
+        <version>4.12.0</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.moesif.api</groupId>
@@ -47,19 +65,9 @@
       <version>1.8.1</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.12.7.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okio</groupId>
-      <artifactId>okio</artifactId>
-      <version>3.4.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.11.0</version>
+      <version>4.12.0</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -69,12 +77,12 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.4.12</version>
+      <version>1.4.14</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.14.0</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -85,12 +93,6 @@
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
       <version>1.7</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -105,54 +107,56 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.7.2</version>
-        <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.7.2</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
-      <version>3.7.0</version>
+      <version>3.33.0</version>
     </dependency>
-  </dependencies>
+</dependencies>
 
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
-<!--        <configuration>-->
-<!--          <argLine>-->
-<!--            &#45;&#45;illegal-access=permit-->
-<!--          </argLine>-->
-<!--        </configuration>-->
+        <version>3.5.2</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>3.5.2</version>
         <configuration>
           <argLine>
             --illegal-access=permit
           </argLine>
         </configuration>
       </plugin>
-
+      <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
+          <configuration>
+              <encoding>${project.build.sourceEncoding}</encoding>
+          </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.source}</target>
+          <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -165,7 +169,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -175,7 +179,7 @@
           </execution>
         </executions>
         <configuration>
-          <source>8</source>
+          <source>${maven.compiler.source}</source>
           <excludePackageNames>com.moesif.external.*</excludePackageNames>
         </configuration>
       </plugin>

--- a/src/main/java/com/moesif/sdk/okhttp3client/MoesifResponseHandler.java
+++ b/src/main/java/com/moesif/sdk/okhttp3client/MoesifResponseHandler.java
@@ -19,18 +19,18 @@ import java.util.List;
 public class MoesifResponseHandler implements ResponseHandler {
     private static final Logger logger = LoggerFactory.getLogger(
                                             MoesifResponseHandler.class);
-    private EventRequestModel loggedRequest;
-    private EventResponseModel loggedResponse;
-    private ByteArrayOutputStream outputStream;
-    private Boolean jsonHeader;
-    private String moesifApplicationId;
-    private static Long maxAllowedBodySize;
-    private EventModelBuffer buffer;
-    private String userId;
-    private String companyId;
-    private String sessionToken;
-    private Object metadata;
-    private IMoesifEventFilter moesifEventFilter;
+    private final EventRequestModel loggedRequest;
+    private final EventResponseModel loggedResponse;
+    private final ByteArrayOutputStream outputStream;
+    private final Boolean jsonHeader;
+    private final String moesifApplicationId;
+    private final Long maxAllowedBodySize;
+    private final EventModelBuffer buffer;
+    private final String userId;
+    private final String companyId;
+    private final String sessionToken;
+    private final Object metadata;
+    private final IMoesifEventFilter moesifEventFilter;
 
     public MoesifResponseHandler(EventRequestModel loggedRequest,
                                  EventResponseModel loggedResponse,
@@ -105,9 +105,9 @@ public class MoesifResponseHandler implements ResponseHandler {
                         loggedEvents);
             }
         } catch (IllegalArgumentException e) {
-            logger.warn("Is Moesif Application ID configured?", e.getMessage());
+            logger.warn("Is Moesif Application ID configured? {}", e.getMessage());
         } catch (Exception e) {
-            logger.warn("Error creating or submitting event", e.getMessage());
+            logger.warn("Error creating or submitting event {}", e.getMessage());
         } catch (Throwable throwable) {
             logger.warn("Error with throwable", throwable);
         }
@@ -117,8 +117,7 @@ public class MoesifResponseHandler implements ResponseHandler {
             boolean isJsonHeader,
             EventResponseModel loggedResponse,
             ByteArrayOutputStream bodyStream,
-            Long maxAllowedBodySize)
-            throws IOException {
+            Long maxAllowedBodySize) {
         if ((null != bodyStream) && (bodyStream.size() <= maxAllowedBodySize)){
             if (isJsonHeader) {
                 try {

--- a/src/main/java/com/moesif/sdk/okhttp3client/MoesifResponseHandler.java
+++ b/src/main/java/com/moesif/sdk/okhttp3client/MoesifResponseHandler.java
@@ -109,7 +109,6 @@ public class MoesifResponseHandler implements ResponseHandler {
         } catch (Exception e) {
             logger.warn("Error creating or submitting event", e.getMessage());
         } catch (Throwable throwable) {
-            // jackson 2.8.4 works. 2.11.3 might not.
             logger.warn("Error with throwable", throwable);
         }
     }

--- a/src/test/java/com/moesif/test/unit/helpers/UrlsForTest.java
+++ b/src/test/java/com/moesif/test/unit/helpers/UrlsForTest.java
@@ -6,7 +6,7 @@ public class UrlsForTest {
     public static final String URL_200_IP = "https://8.8.8.8/";
     public static final String URL_200_HTTP_HTML_NO_PATH = "http://dns.google/";
     public static final String URL_301_HTTP_NO_BODY = "http://github.com/robots.txt";
-    public static final String URL_200_HTTP_TEXT ="http://eu.httpbin.org/robots.txt";
+    public static final String URL_200_HTTP_TEXT ="https://httpstat.us/200";
     public static final String URL_404 = "https://google.com/expect-404";
     public static final String URL_DOMAIN_NOT_EXIST = "https://domain.not.exist/expect-no-domain";
     public static final String URL_POST_200_JSON = "https://jsonplaceholder.typicode.com/posts/1";

--- a/src/test/java/com/moesif/test/unit/helpers/UrlsForTest.java
+++ b/src/test/java/com/moesif/test/unit/helpers/UrlsForTest.java
@@ -5,14 +5,11 @@ public class UrlsForTest {
     public static final String URL_200_FULL_JSON_NO_CONT_LEN_RESP = "https://jsonplaceholder.typicode.com/users";
     public static final String URL_200_IP = "https://8.8.8.8/";
     public static final String URL_200_HTTP_HTML_NO_PATH = "http://dns.google/";
-    public static final String URL_301_HTTP_NO_BODY = "http://github.com/robots.txt";
     public static final String URL_200_HTTP_TEXT ="https://httpstat.us/200";
     public static final String URL_404 = "https://google.com/expect-404";
     public static final String URL_DOMAIN_NOT_EXIST = "https://domain.not.exist/expect-no-domain";
     public static final String URL_POST_200_JSON = "https://jsonplaceholder.typicode.com/posts/1";
     public static final String SAMPLE_JSON_BODY = "{\"uid\":1, \"title\":\"hello\\n there\"}";
-
-    public static final String URL_200_PNG = "https://github.com/fluidicon.png";
 
     // basic auth url, user, pwd from OkHttp recipe:
     // https://square.github.io/okhttp/recipes/#handling-authentication-kt-java

--- a/src/test/java/com/moesif/test/unit/sdk/okhttpclient/MoesifApiConnConfigUnitTest.java
+++ b/src/test/java/com/moesif/test/unit/sdk/okhttpclient/MoesifApiConnConfigUnitTest.java
@@ -4,7 +4,6 @@ import com.moesif.sdk.okhttp3client.config.EnvironmentVars;
 import com.moesif.sdk.okhttp3client.config.MoesifApiConnConfig;
 import org.apache.commons.collections.CollectionUtils;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.commons.util.StringUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,8 +27,8 @@ public class MoesifApiConnConfigUnitTest {
 
     @Test
     public void readAppId(){
-        assertTrue("aaa".equals(MoesifApiConnConfig.cleanAppId("'aaa\"")));
-        assertTrue("aaa".equals(MoesifApiConnConfig.cleanAppId("\"aaa'")));
-        assertTrue("aaa".equals(MoesifApiConnConfig.cleanAppId(" 'aaa \" '")));
+        assertEquals("aaa", MoesifApiConnConfig.cleanAppId("'aaa\""));
+        assertEquals("aaa", MoesifApiConnConfig.cleanAppId("\"aaa'"));
+        assertEquals("aaa", MoesifApiConnConfig.cleanAppId(" 'aaa \" '"));
     }
 }

--- a/src/test/java/com/moesif/test/unit/sdk/okhttpclient/MoesifApiConnConfigUnitTest.java
+++ b/src/test/java/com/moesif/test/unit/sdk/okhttpclient/MoesifApiConnConfigUnitTest.java
@@ -10,25 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MoesifApiConnConfigUnitTest {
-
-    /*@Test
-    void testEnsureEnvVarAppIdNotSet() {
-        assertTrue(
-                StringUtils.isBlank(EnvironmentVars.loadVar(
-                        EnvironmentVars.MOESIF_APPLICATION_ID)));
-    }*/
-
-    /*@Test
-    void testDoesntExistLoadMoesifApplicationId() {
-        assertTrue(
-                StringUtils.isBlank(
-                        EnvironmentVars.loadMoesifApplicationId()));
-        assertTrue(
-                StringUtils.isBlank(
-                        new MoesifApiConnConfig().getApplicationId()));
-        return;
-    }*/
-
     @Test
     void testMoesifApiConnConfigUnit() {
         MoesifApiConnConfig connNoParam = new MoesifApiConnConfig();


### PR DESCRIPTION
Use OkHTTP BOM dependency to ensure correct version transitive deps

Sync logger dep versions, update important deps where able

Java 8 was broken for some deps, so bump version to Java 11 to fix

Remove redundant dependency declarations which are transitive deps of other key dependencies to reduce the amount of explicit version dependency and allow our direct deps to dictate the version of their own dependencies for easier maintenance going forward

Clean up the easy project code analysis warnings 

